### PR TITLE
chore: clean up GOPATH variable

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -8,9 +8,6 @@ components:
       memoryLimit: 2Gi
       mountSources: true
       env:
-        - name: GOPATH
-          # replicate the GOPATH from the plugin
-          value: /projects/.che/gopath:/projects
         - name: GOCACHE
           # replicate the GOCACHE from the plugin, even though the cache is not shared
           # between the two


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

With the update to go language server in Devspaces UDI image https://github.com/redhat-developer/devspaces-images/pull/298/files, which will be located in `/home/user/go/bin/gopls` directory, which coresponds with default GOPATH location, seems like there will be no need for these existing GOPATH declarations:
- /projects/.che/gopath is the old location of go language server
- /projects/ doesn't contain any go binaries either

The sample has been tested with this new gopls & removed GOPATH, so that it build&run commands are running successfully

re: https://issues.redhat.com/browse/CRW-3103