### PR TITLE
chore: add redhat.fabric8-analytics extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "golang.go"
+    "golang.go",
+    "redhat.fabric8-analytics"
   ]
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/devspaces-samples/golang-health-check/pull/2

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This pull request adds `redhat.fabric8-analytics` extension. 

Solves https://issues.redhat.com/browse/CRW-3302, https://issues.redhat.com/browse/CRW-3216

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/golang-health-check?che-editor=che-incubator/che-code/insiders
