### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -18,7 +18,7 @@ components:
       endpoints:
         - exposure: public
           name: 'health-check-endpoint'
-          protocol: http
+          protocol: https
           targetPort: 8080
 commands:
   - id: build


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 12 21-14_37_32](https://github.com/devspaces-samples/golang-health-check/assets/1271546/e0b3cd27-db2b-467d-9922-eb2ee7dc2899)


https://issues.redhat.com/browse/CRW-5377