### PR TITLE
Updates devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: golang
 components:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -17,7 +17,7 @@ components:
           value: /tmp/.cache
       endpoints:
         - exposure: public
-          name: 'health-check-endpoint'
+          name: 'health-check'
           protocol: https
           targetPort: 8080
 commands:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985

![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-16_20_51](https://github.com/devspaces-samples/golang-health-check/assets/1271546/fccfe20e-60c7-48bf-9fb7-01d3076cdc8e)



